### PR TITLE
use a different 'source' function to write byte array data

### DIFF
--- a/dcc-common-es/src/main/java/org/icgc/dcc/dcc/common/es/impl/DefaultDocumentWriter.java
+++ b/dcc-common-es/src/main/java/org/icgc/dcc/dcc/common/es/impl/DefaultDocumentWriter.java
@@ -127,7 +127,7 @@ public class DefaultDocumentWriter implements DocumentWriter {
   }
 
   private IndexRequest createRequest(String id, IndexDocumentType type, byte[] source) {
-    return indexRequest(indexName).type(type.getIndexType()).id(id).source(SMILE, source);
+    return indexRequest(indexName).type(type.getIndexType()).id(id).source(source, SMILE);
   }
 
   private boolean isBigDocument(int length) {


### PR DESCRIPTION
switch from source(XContentType xContentType, Object... source) to source(byte[] source, XContentType xContentType)